### PR TITLE
Fixes to configuration defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# IntelliJ
+.idea

--- a/src/contributors/git.test.ts
+++ b/src/contributors/git.test.ts
@@ -7,6 +7,49 @@ import { GitInfoContributor } from './git.ts';
 vi.mock('git-last-commit');
 
 describe('GitInfoContributor', () => {
+  it('returns the last commit details using the SHORT format by default', async () => {
+    // Given
+    const config: GitContributorConfig = {
+      enabled: true,
+    };
+
+    vi.mocked(getLastCommit).mockImplementation((callback: GetLastCommitCallback) => {
+      const commit: Commit = {
+        author: {
+          email: 'steven.smith@example.com',
+          name: 'steven smith',
+        },
+        authoredOn: '1725806917',
+        body: 'test commit',
+        branch: 'main',
+        committedOn: '1725806917',
+        committer: {
+          email: 'steven.smith@example.com',
+          name: 'steven smith',
+        },
+        hash: '2a4dff17e123acf34acdc',
+        sanitizedSubject: 'test commit',
+        shortHash: '2a4dff1c',
+        subject: 'test commit',
+        tags: ['v1.0.0'],
+      };
+      callback(undefined!, commit);
+    });
+
+    // When
+    const response: Promise<Json> = GitInfoContributor(config);
+
+    // Then
+    await expect(response).resolves.toStrictEqual({
+      branch: 'main',
+      commit: {
+        id: '2a4dff1c',
+        tags: ['v1.0.0'],
+        time: '1725806917',
+      },
+    });
+  });
+
   it('returns the last commit details using the SHORT format', async () => {
     // Given
     const config: GitContributorConfig = {

--- a/src/contributors/git.ts
+++ b/src/contributors/git.ts
@@ -9,10 +9,12 @@ const GitInfoContributor: Contributor<GitContributorConfig> = (config: GitContri
         reject(error);
       }
 
+      const commitId = config.commitId || 'SHORT';
+
       resolve({
         branch: commit.branch,
         commit: {
-          id: config.commitId === 'SHORT' ? commit.shortHash : commit.hash,
+          id: commitId === 'SHORT' ? commit.shortHash : commit.hash,
           tags: commit.tags,
           time: commit.committedOn,
         },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,9 +6,9 @@ import type { BuildInfoFilePluginConfig, Json } from './types.ts';
 const defaultBuildInfoFilePluginConfig: BuildInfoFilePluginConfig = {
   contributors: {
     git: { commitId: 'SHORT', enabled: true },
-    node: { enabled: false },
+    node: { enabled: true },
     package: { enabled: true },
-    platform: { enabled: false },
+    platform: { enabled: true },
   },
   filename: 'info.json',
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type ContributorConfig = {
 };
 
 export type GitContributorConfig = ContributorConfig & {
-  commitId: 'SHORT' | 'LONG';
+  commitId?: 'SHORT' | 'LONG';
 };
 
 export type Contributor<T> = (config: T) => Promise<Json>;


### PR DESCRIPTION
Some fixes around default fallbacks including:

- `git` - Making the `SHORT` format the default when a `commitId` isnt specific
- `git` - Making `commitId` optional
- `plugin` - enabled the `node` and `platform` contributors by default 