### PR TITLE
Adding support for the info property within plugin config

### DIFF
--- a/src/info.test.ts
+++ b/src/info.test.ts
@@ -118,4 +118,39 @@ describe('#createInfo', () => {
     expect(await NodeInfoContributor).not.toBeCalled();
     expect(await PlatformInfoContributor).not.toBeCalled();
   });
+
+  it('should merge the provided static info when provided', async () => {
+    // Given
+    const pluginConfig: BuildInfoFilePluginConfig = {
+      info: { foo: 'bar', version: 1 },
+    };
+
+    // When
+    const response = createInfo(pluginConfig);
+
+    // Then
+    await expect(response).resolves.toStrictEqual({
+      info: { foo: 'bar', version: 1 },
+    });
+  });
+
+  it('should prioritise the provided static info over a custom contributor called "info"', async () => {
+    // Given
+    const pluginConfig: BuildInfoFilePluginConfig = {
+      contributors: {
+        info: vi.fn().mockResolvedValue(() => {
+          return { message: 'generated message' };
+        }),
+      },
+      info: { message: 'static message' },
+    };
+
+    // When
+    const response = createInfo(pluginConfig);
+
+    // Then
+    await expect(response).resolves.toStrictEqual({
+      info: { message: 'static message' },
+    });
+  });
 });

--- a/src/info.ts
+++ b/src/info.ts
@@ -22,5 +22,9 @@ export const createInfo = async (config: BuildInfoFilePluginConfig): Promise<Jso
     }
   }
 
+  if (config.info) {
+    info['info'] = config.info;
+  }
+
   return info;
 };


### PR DESCRIPTION
Enables users to provide an "info" object that can be populated with any object structure.